### PR TITLE
Booking can start on the same day

### DIFF
--- a/api/src/Entity/Booking.php
+++ b/api/src/Entity/Booking.php
@@ -19,8 +19,8 @@ readonly class Booking
      */
     public function __construct(DatePoint $startDate, DatePoint $endDate)
     {
-        $now = new DatePoint();
-        if ($startDate < $now) {
+        $today = new DatePoint('today');
+        if ($startDate < $today) {
             throw new BookingInThePastException();
         }
         if ($endDate < $startDate) {

--- a/api/tests/BookingTest.php
+++ b/api/tests/BookingTest.php
@@ -13,8 +13,8 @@ class BookingTest extends TestCase
 {
     public function testCanReadDatesAfterCreation(): void
     {
-        $startDate = new DatePoint('tomorrow');
-        $endDate = new DatePoint('tomorrow + 1 day');
+        $startDate = new DatePoint('today');
+        $endDate = new DatePoint('tomorrow');
 
         $booking = new Booking($startDate, $endDate);
 

--- a/testlist.md
+++ b/testlist.md
@@ -6,5 +6,8 @@
 ~~New booking should be in the future~~
 ~~Start must be before end
 End must be before start~~
-Room should be available
+**Room should be available**
+(watch for partial overlaps)
+(end on one day = can start another on same day)
 ~~Start and end can't be on same day~~
+~~Can start booking today~~


### PR DESCRIPTION
A hotel booking for "today" means check-in happens tonight. We must allow these cases. Previously, we only allowed bookings for "tomorrow" and later.